### PR TITLE
Fix using own id_rsa as encryption key

### DIFF
--- a/bin/ch
+++ b/bin/ch
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION="0.1.0"
+VERSION="0.2.0"
 
 #
 # Output version
@@ -34,11 +34,12 @@ usage() {
 
 encrypt() {
   user=$1
-  pem=/tmp/$user.pub.pem
+  pub=/tmp/$user.pub
+  pem=$pub.pem
 
   if [[ ! -f $pem ]]; then
-    curl -s https://github.com/$user.keys | grep ssh-rsa | head -n 1 > /tmp/$user.pub
-    test -f $pem || openssl rsa -in ~/.ssh/id_rsa -pubout > $pem
+    curl -s https://github.com/$user.keys | grep ssh-rsa | head -n 1 > $pub
+    test -f $pem || ssh-keygen -f $pub -e -m PKCS8 > $pem
   fi
 
   cat | openssl rsautl -encrypt -pubin -inkey $pem | base64

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cipherhub.sh",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "shell alternative to substacks cipherhub",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The downloaded public key was not used when creating the PEM key needed
for encryption. Instead, the sender's own public key was used.

Now we convert the receiver's public key properly using ssh-keygen.